### PR TITLE
fix Reference Error relating to Chinese date feature

### DIFF
--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -7,7 +7,7 @@
     </div>
     <div class="post-meta">
         <%
-            const dat = date(post.date, "YYYY/MM/DD");
+            const dat = date(page.date, "YYYY/MM/DD");
             const chinese_date = to_chinese_date(dat);
             const result = theme.to_chinese_date ? chinese_date : dat;
         %>


### PR DESCRIPTION

[此处](https://github.com/eatradish/Seje/blob/3f7fe2f83af32f5fec53a2fdd206fe10c9adf58c/layout/post.ejs#L10)为 ```post``` 时会在生成静态文件时出现以下错误信息（且生成之后除了主页和归档，其他所有页面无法打开) :

```
ERROR ReferenceError: /Path/to/Blog/themes/Seje/layout/post.ejs:9
    7|     </div>
    8|     <div class="post-meta">
 >> 9|         <%
    10|             const dat = date(post.date, "YYYY/MM/DD");
    11|             const chinese_date = to_chinese_date(dat);
    12|             const result = theme.to_chinese_date ? chinese_date : dat;

post is not defined
    at eval (/Path/to/Blog/themes/Seje/layout/post.ejs:19:30)
    at post (/Path/to/Blog/node_modules/ejs/lib/ejs.js:682:17)
    at _View._compiled (/Path/to/Blog/node_modules/hexo/lib/theme/view.js:136:50)
    at _View.render (/Path/to/Blog/node_modules/hexo/lib/theme/view.js:39:17)
    at /Path/to/Blog/node_modules/hexo/lib/hexo/index.js:64:21
    at tryCatcher (/Path/to/Blog/node_modules/bluebird/js/release/util.js:16:23)
    at /Path/to/Blog/node_modules/bluebird/js/release/method.js:15:34
    at RouteStream._read (/Path/to/Blog/node_modules/hexo/lib/hexo/router.js:30:5)
    at RouteStream.Readable.read (_stream_readable.js:475:10)
    at resume_ (_stream_readable.js:962:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  path: '/Path/to/Blog/themes/Seje/layout/post.ejs'
```



将 ```post``` 替换为 ```page``` 之后错误消失

